### PR TITLE
Remove redundant check

### DIFF
--- a/accession/accession.py
+++ b/accession/accession.py
@@ -113,9 +113,7 @@ class Accession(object):
                                                  submitted_file_path)
             self.new_files.append(encode_posted_file)
             return encode_posted_file
-        elif (file_exists
-              and file_exists.get('status')
-              in ['deleted', 'revoked']):
+        elif file_exists.get('status') in ['deleted', 'revoked']):
             encode_file.update(submitted_file_path)
             # Update the file to current user
             # TODO: Reverse this when duplicate md5sums are enabled


### PR DESCRIPTION
`file_exists = self.file_at_portal(gs_file.filename)`
As a result `file_exists` must be either `None` (when the file does not exist on the server), or a dict returned by `self.conn.get` (when it does)
The dict can either be empty (when the file does not exist on the server – but this case should return none) or can contain data.
As both `{}` (empty dictionary) and `None` evaluate to false (meaning the file does not exist)
and only the dict with values evaluates to true (meaning the file does exist),
The expected behavior can be satisfied without the second check to file_exists

TLDR: There is no case where either `not file_exists` or `file_exists` will evaluate to false, as a result, the extra check for `file_exists` is redundant and unnecessary.