### PR TITLE
PIP-818 file filtering by status implemented

### DIFF
--- a/accession/accession.py
+++ b/accession/accession.py
@@ -100,7 +100,7 @@ class Accession(object):
 
     @staticmethod
     def filter_encode_files_by_status(
-        encode_files, forbidden_statuses=["replaced", "revoked", "deleted"]
+        encode_files, forbidden_statuses=("replaced", "revoked", "deleted")
     ):
         """Filter out files whose statuses are not allowed.
 

--- a/accession/accession.py
+++ b/accession/accession.py
@@ -85,7 +85,6 @@ class Accession(object):
             dict: Dictionary representation of the matching file object on portal.
             None if no matching objects are found.
         """
-        self.wait_for_portal()
         md5sum = self.backend.md5sum(file)
         search_param = [("md5sum", md5sum), ("type", "File")]
         encode_files = self.conn.search(search_param)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -89,6 +89,7 @@ def local_encoded_server(
             continue
         container.kill()
         raise RuntimeError("Elasticsearch took too long to index")
+    sleep(10)
     yield server_address
     container.kill()
 

--- a/tests/test_accession.py
+++ b/tests/test_accession.py
@@ -33,9 +33,9 @@ def mirna_accessioner(accessioner_factory):
 
 @pytest.mark.docker
 @pytest.mark.filesystem
-def test_file_at_portal(mirna_accessioner):
+def test_get_encode_file_matching_md5_of_blob(mirna_accessioner):
     fastq = mirna_accessioner.analysis.raw_fastqs[0]
-    portal_file = mirna_accessioner.file_at_portal(fastq.filename)
+    portal_file = mirna_accessioner.get_encode_file_matching_md5_of_blob(fastq.filename)
     assert portal_file.get("fastq_signature")
 
 
@@ -108,7 +108,7 @@ def test_get_derived_from(mirna_accessioner):
     bam = [file for file in task.output_files if "bam" in file.filekeys][0]
     raw_fastq_inputs = list(set(mirna_accessioner.raw_fastq_inputs(bam)))
     accession_ids = [
-        mirna_accessioner.file_at_portal(file.filename).get("accession")
+        mirna_accessioner.get_encode_file_matching_md5_of_blob(file.filename).get("accession")
         for file in raw_fastq_inputs
     ]
     params = bowtie_step["wdl_files"][0]["derived_from_files"][0]
@@ -137,7 +137,7 @@ def test_get_derived_from_all(mirna_accessioner):
     bam = [file for file in task.output_files if "bam" in file.filekeys][0]
     raw_fastq_inputs = list(set(mirna_accessioner.raw_fastq_inputs(bam)))
     accession_ids = [
-        mirna_accessioner.file_at_portal(file.filename).get("accession")
+        mirna_accessioner.get_encode_file_matching_md5_of_blob(file.filename).get("accession")
         for file in raw_fastq_inputs
     ]
     derived_from_files = bowtie_step["wdl_files"][0]["derived_from_files"]

--- a/tests/test_accession.py
+++ b/tests/test_accession.py
@@ -108,7 +108,9 @@ def test_get_derived_from(mirna_accessioner):
     bam = [file for file in task.output_files if "bam" in file.filekeys][0]
     raw_fastq_inputs = list(set(mirna_accessioner.raw_fastq_inputs(bam)))
     accession_ids = [
-        mirna_accessioner.get_encode_file_matching_md5_of_blob(file.filename).get("accession")
+        mirna_accessioner.get_encode_file_matching_md5_of_blob(file.filename).get(
+            "accession"
+        )
         for file in raw_fastq_inputs
     ]
     params = bowtie_step["wdl_files"][0]["derived_from_files"][0]
@@ -137,7 +139,9 @@ def test_get_derived_from_all(mirna_accessioner):
     bam = [file for file in task.output_files if "bam" in file.filekeys][0]
     raw_fastq_inputs = list(set(mirna_accessioner.raw_fastq_inputs(bam)))
     accession_ids = [
-        mirna_accessioner.get_encode_file_matching_md5_of_blob(file.filename).get("accession")
+        mirna_accessioner.get_encode_file_matching_md5_of_blob(file.filename).get(
+            "accession"
+        )
         for file in raw_fastq_inputs
     ]
     derived_from_files = bowtie_step["wdl_files"][0]["derived_from_files"]
@@ -495,3 +499,13 @@ def mock_accession_unreplicated(
 @pytest.fixture
 def mock_file() -> MockFile:
     return MockFile("gs://foo/bar", 123, "abc")
+
+
+def test_filter_encode_files_by_status_one_hit():
+    files = [{"status": "foo"}, {"status": "bar"}, {"status": "deleted"}]
+    assert len(Accession.filter_encode_files_by_status(files)) == 2
+
+
+def test_filter_encode_files_by_status_no_hits():
+    files = [{"status": "foo"}]
+    assert len(Accession.filter_encode_files_by_status(files)) == 1


### PR DESCRIPTION
In case input fastqs were mistakenly submitted several times, the ones replaced, revoked and deleted should be ignored. 